### PR TITLE
Enable Wayland socket access

### DIFF
--- a/sh.cider.Cider.yml
+++ b/sh.cider.Cider.yml
@@ -15,9 +15,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
-  # needs electron v11 (chromium v87) or newer with ozone enabled
-  # https://github.com/electron/electron/issues/10915
-  #- --socket=wayland
+  - --socket=wayland
   - --socket=x11
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=com.canonical.AppMenu.Registrar


### PR DESCRIPTION
Recent Cider releases are using Electron builds that have the last Ozone Wayland regression fixed.
As far as I can tell, this is working without issues in Sway 1.7, when adding the `--ozone-platform=wayland` flag.

Auto Ozone platform selection with the `--ozone-platform-hint=auto` flag doesn't seem to work yet,
so switching to `socket=fallback-x11` is not on the table, and in any case, there's no IME support with
Ozone Wayland.